### PR TITLE
Fix source file link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ CoRrEcTiNg An OvErSiGhT iN hTmL
 
 A `<sponge-case>` web component for your website.
 
-Source: [sponge-case.js](https://github.com/MWDelaney/sponge-case/blob/master/src/sponge-case.js)
+Source: [sponge-case.js](https://github.com/MWDelaney/sponge-case/blob/main/src/sponge-case.js)
 
 HTML includes tags for text styling, like `<strong>` and `<em>`, which help convey the intent or emotion behind a piece of text, but HTML does not yet support Sponge-Case, an important text style for mocking individuals on the internet.
 


### PR DESCRIPTION
GitHub is smart enough to redirect this, but it still shows a message about it.